### PR TITLE
Set doctrine/mongodb dependecy to 1.1.* to use a stable versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         "symfony/yaml": "2.5.*",
         "symfony/console": "2.5.*",
         "symfony/class-loader": "2.5.*",
-        "doctrine/mongodb": "1.2.*@dev"
+        "doctrine/mongodb": "1.1.*"
     }
 }


### PR DESCRIPTION
Ensure bundle uses stable versions of `doctrine/mongodb` instead of using `dev-master`