### PR TITLE
Add bc compatibility with Symfony 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+env:
+  - PREFER_LOWEST="--prefer-lowest"
+  - PREFER_LOWEST=""
+
 php:
     - 5.4
     - 5.5
@@ -10,8 +14,8 @@ services:
 before_script:
     - phpenv config-add .travis.php.ini
     - cp config/parameters.yml.dist config/parameters.yml
-    - wget http://getcomposer.org/composer.phar -nc
-    - php composer.phar dump-autoload
-    - php composer.phar install
+    - composer dump-autoload
+    - composer self-update
+    - composer update --prefer-source $PREFER_LOWEST 
 
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "symfony/yaml": "~2.3",
         "symfony/console": "~2.3",
         "symfony/class-loader": "~2.3",
+        "doctrine/common": "~2.2",
         "doctrine/mongodb": "1.1.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     "require": {
         "php": ">=5.4.0",
         "ext-mongo": "*",
-        "symfony/yaml": "2.5.*",
-        "symfony/console": "2.5.*",
-        "symfony/class-loader": "2.5.*",
+        "symfony/yaml": "~2.3",
+        "symfony/console": "~2.3",
+        "symfony/class-loader": "~2.3",
         "doctrine/mongodb": "1.1.*"
     }
 }


### PR DESCRIPTION
- [x] Ensure lib is tested against lowest dependencies.

Add dependency of `doctrine/common:~2.2` because it looks like [`doctrine/mongodb`](https://github.com/doctrine/mongodb/blob/master/composer.json#L17) package has min dependency on `~2.1`.

Created PR to ensure this won't happen:
https://github.com/doctrine/mongodb/pull/215  Ensure it is tested against lowest dependencies.
https://github.com/doctrine/mongodb/pull/216  Remove `composer.lock` to avoid locking dependencies.

This should fix #6 make compatible with symfony 2.3 versions. 