### PR TITLE
Use absolute path to generate migration.

### DIFF
--- a/src/Mongrate/Command/GenerateMigrationCommand.php
+++ b/src/Mongrate/Command/GenerateMigrationCommand.php
@@ -27,7 +27,7 @@ class GenerateMigrationCommand extends BaseCommand
             mkdir($targetDirectory, 0766, true);
         }
 
-        $iterator = new \DirectoryIterator('resources/migration-template/');
+        $iterator = new \DirectoryIterator(__DIR__ . '/../../../resources/migration-template/');
 
         foreach ($iterator as $file) {
             if ($file->getFileName() === '.'|| $file->getFileName() === '..') {


### PR DESCRIPTION
- [x] Use absolute path to generate migration.

This will fix [issue in MongrateBundle](https://github.com/amyboyd/mongrate-bundle/issues/10) cause by relative path.