### PR TITLE
Add phpunit as dev dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_script:
     - composer self-update
     - composer update --prefer-source $PREFER_LOWEST 
 
-script: phpunit
+script: bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "doctrine/mongodb": "1.1.*"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "~2.0",
+        "phpunit/phpunit": "^4.7"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
- [x] Add [phpunit/phpunit](https://packagist.org/packages/phpunit/phpunit) package as dev dependency to `composr.json`.

This will enable developers to run tests locally.